### PR TITLE
Fix (clojure.repl/doc VAR).

### DIFF
--- a/src/clj_slackbot/core/handler.clj
+++ b/src/clj_slackbot/core/handler.clj
@@ -27,7 +27,8 @@
      (let [p (if channel {:channel channel} {})]
        (client/post post-url
                    {:content-type :json
-                    :form-params (assoc p :text s)})))
+                    :form-params (assoc p :text s)
+                    :query-params {"parse" "none"}})))
   ([s]
      (post-to-slack s nil)))
 


### PR DESCRIPTION
Hi, for some reason the slack server is doing some weird stuff with the output from (clojure.repl/doc VAR), asking them to not parse seems to fix it. Here are screenshots of before/after the patch:

![before](https://cloud.githubusercontent.com/assets/194071/8263370/baa6df88-168e-11e5-97f8-3f750fe00200.png)
![after](https://cloud.githubusercontent.com/assets/194071/8263369/baa53ec6-168e-11e5-9752-b3f86d63e000.png)
