### PR TITLE
Simple fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ This bot now supports different kinds of comm-links (communication channels to t
 Webhook configuration needs four things defined in `config.edn`:
 
 - `:comm :clj-slackbot.comms.slack-web-hook/start`
-- `:post-url` - The post URL to post responses to a channel.
 - `:command-token` - The token you get when you create a slash command in slack. Usually something like `/clj`.
 - `:port` - The port to run the web-server on.
 

--- a/config.example.edn
+++ b/config.example.edn
@@ -2,5 +2,4 @@
  :api-token "XXX"
  :prefix ","
  :port 3000
- :command-token "XXX"
- :post-url "XXX"}
+ :command-token "XXX"}

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,6 @@
   :uberjar-name "clj-slackbot.jar"
   :main clj-slackbot.core
   :profiles
-  {:dev {:repl-options {:init-ns clj-slackbot.core.handler}
-         :dependencies [[javax.servlet/servlet-api "2.5"]
-                        [ring-mock "0.1.5"]]}
+  {:dev     {:dependencies [[javax.servlet/servlet-api "2.5"]
+                            [ring-mock "0.1.5"]]}
    :uberjar {:aot :all}})

--- a/src/clj_slackbot/comms/slack_web_hook.clj
+++ b/src/clj_slackbot/comms/slack_web_hook.clj
@@ -18,23 +18,25 @@
   ([post-url s]
    (post-to-slack post-url s nil)))
 
-(defn handle-clj [params command-token cin]
-  (if-not (= (:token params) command-token)
+(defn handle-clj
+  [{:keys [token channel_id channel_name response_url text user_name]} command-token cin]
+  (if-not (= token command-token)
     {:status 403 :body "Unauthorized"}
-    (let [channel (case (:channel_name params)
-                    "directmessage" (str "@" (:user_name params))
-                    "privategroup" (:channel_id params)
-                    (str "#" (:channel_name params)))]
+    (let [channel (case channel_name
+                    "directmessage" (str "@" user_name)
+                    "privategroup" channel_id
+                    (str "#" channel_name))]
       ;; send the form to our evaluator and get out of here
-      (>!! cin {:input (:text params)
+      (>!! cin {:input text
                 :meta  {:channel      channel
-                        :response-url (:response_url params)
-                        :user (:user_name params)}})
+                        :response-url response_url
+                        :user user_name}})
 
       {:status 200 :body "..." :headers {"Content-Type" "text/plain"}})))
 
 
-(defn start [{:keys [port command-token]}]
+(defn start
+  [{:keys [port command-token]}]
   ;; check we have everything
   (when (some nil? [port command-token])
     (throw (Exception. "Cannot initialize. Missing port or command-token")))

--- a/src/clj_slackbot/comms/slack_web_hook.clj
+++ b/src/clj_slackbot/comms/slack_web_hook.clj
@@ -10,13 +10,13 @@
 
 (defn post-to-slack
   ([post-url s channel]
-     (let [p (if channel {:channel channel} {})]
-       (client/post post-url
-                   {:content-type :json
-                    :form-params (assoc p :text s)
-                    :query-params {"parse" "none"}})))
+   (let [p (if channel {:channel channel} {})]
+     (client/post post-url
+                  {:content-type :json
+                   :form-params  (assoc p :text s)
+                   :query-params {"parse" "none"}})))
   ([post-url s]
-     (post-to-slack post-url s nil)))
+   (post-to-slack post-url s nil)))
 
 (defn handle-clj [params command-token cin]
   (if-not (= (:token params) command-token)
@@ -27,7 +27,9 @@
                     (str "#" (:channel_name params)))]
       ;; send the form to our evaluator and get out of here
       (>!! cin {:input (:text params)
-                :meta {:channel channel}})
+                :meta  {:channel      channel
+                        :response-url (:response_url params)
+                        :user (:user_name params)}})
 
       {:status 200 :body "..." :headers {"Content-Type" "text/plain"}})))
 

--- a/src/clj_slackbot/comms/slack_web_hook.clj
+++ b/src/clj_slackbot/comms/slack_web_hook.clj
@@ -10,11 +10,11 @@
 
 (defn post-to-slack
   ([post-url s channel]
-   (let [p (if channel {:channel channel} {})]
-     (client/post post-url
-                  {:content-type :json
-                   :form-params  (assoc p :text s)
-                   :query-params {"parse" "none"}})))
+   (client/post post-url
+     {:content-type :json
+      :form-params  (cond-> {:text s}
+                      channel (assoc :channel channel))
+      :query-params {"parse" "none"}}))
   ([post-url s]
    (post-to-slack post-url s nil)))
 

--- a/src/clj_slackbot/comms/slack_web_hook.clj
+++ b/src/clj_slackbot/comms/slack_web_hook.clj
@@ -34,10 +34,10 @@
       {:status 200 :body "..." :headers {"Content-Type" "text/plain"}})))
 
 
-(defn start [{:keys [port post-url command-token] :as config}]
+(defn start [{:keys [port command-token]}]
   ;; check we have everything
-  (when (some nil? [port post-url command-token])
-    (throw (Exception. "Cannot initialize. Missing port, post-url or command-token")))
+  (when (some nil? [port command-token])
+    (throw (Exception. "Cannot initialize. Missing port or command-token")))
 
   (println ":: starting http server on port:" port)
   (let [cin (async/chan 10)
@@ -53,7 +53,8 @@
       (if-not res
         (println "The form output channel has been closed. Leaving listen loop.")
         (let [result (:evaluator/result res)
-              channel (get-in res [:meta :channel])]
+              channel (get-in res [:meta :channel])
+              post-url (get-in res [:meta :response-url])]
           (post-to-slack
             post-url
             (util/format-result-for-slack result)

--- a/src/clj_slackbot/comms/slack_web_hook.clj
+++ b/src/clj_slackbot/comms/slack_web_hook.clj
@@ -21,7 +21,7 @@
 (defn handle-clj [params command-token cin]
   (if-not (= (:token params) command-token)
     {:status 403 :body "Unauthorized"}
-    (let [channel (condp = (:channel_name params)
+    (let [channel (case (:channel_name params)
                     "directmessage" (str "@" (:user_name params))
                     "privategroup" (:channel_id params)
                     (str "#" (:channel_name params)))]

--- a/src/clj_slackbot/comms/slack_web_hook.clj
+++ b/src/clj_slackbot/comms/slack_web_hook.clj
@@ -49,11 +49,10 @@
                   (route/not-found "Not Found"))
                 (wrap-defaults api-defaults))]
     ;; start the loops we need to read back eval responses
-    (go-loop [res (<!! cout)]
+    (go-loop [{{post-url :response-url channel :channel} :meta :as res} (<!! cout)]
       (if-not res
         (println "The form output channel has been closed. Leaving listen loop.")
-        (let [channel (get-in res [:meta :channel])
-              post-url (get-in res [:meta :response-url])]
+        (do
           (post-to-slack
             post-url
             (util/format-result-for-slack res)

--- a/src/clj_slackbot/comms/slack_web_hook.clj
+++ b/src/clj_slackbot/comms/slack_web_hook.clj
@@ -52,12 +52,11 @@
     (go-loop [res (<!! cout)]
       (if-not res
         (println "The form output channel has been closed. Leaving listen loop.")
-        (let [result (:evaluator/result res)
-              channel (get-in res [:meta :channel])
+        (let [channel (get-in res [:meta :channel])
               post-url (get-in res [:meta :response-url])]
           (post-to-slack
             post-url
-            (util/format-result-for-slack result)
+            (util/format-result-for-slack res)
             channel)
           (recur (<!! cout)))))
 


### PR DESCRIPTION
First of all, thank you for giving me a starting point for creating a Slash Command for my Slack group. 

Now, right out of the box, I couldn't get this working, and I noticed a few things were off, so I decided that instead of fixing it and moving on, I should offer them back to you, anyway here's a summary:

- Remove `:init-ns` from `project.clj` was causing errors when using REPL
- Add `:response_url` and `:user` keys to the `:meta` map, they are needed
- Remove `:post-url` and use `:response_url` that is given to you on the initial POST
- Update documentation